### PR TITLE
fixes 'use of string literal for Objective-C selectors is deprecated'… for Swift 2.2

### DIFF
--- a/Pod/Classes/Scanner.swift
+++ b/Pod/Classes/Scanner.swift
@@ -139,7 +139,7 @@ extension Scanner: CBCentralManagerDelegate {
         }
         
         self.beaconTimers[identifier]?.invalidate()
-        self.beaconTimers[identifier] = NSTimer.scheduledTimerWithTimeInterval(10, target: self, selector: Selector("beaconTimerExpire:"), userInfo: identifier, repeats: false)
+        self.beaconTimers[identifier] = NSTimer.scheduledTimerWithTimeInterval(10, target: self, selector: #selector(Scanner.beaconTimerExpire(_:)), userInfo: identifier, repeats: false)
     }
     
     @objc func beaconTimerExpire(timer: NSTimer) {


### PR DESCRIPTION
Fixes `use of string literal for Objective-C selectors is deprecated` warning with Swift 2.2 by switching to '#selector' instead